### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darklight-theme

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,12 @@
   <meta name="viewport"
         content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <meta name="google-site-verification" content="SL_TVYoABZxQiU1ZIhWlISt-WcaerRrdzX6UfS-FaW4"/>
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+  <link 
+    rel="stylesheet"
+    href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+    title="docsify-darklight-theme"
+    type="text/css"
+  />
   <link rel="stylesheet" href="styles/style.css">
   <link rel="stylesheet" href="styles/palettify.min.css">
   <link rel="stylesheet" href="styles/grid.min.css">
@@ -50,6 +55,10 @@
     executeScript: true,
     auto2top: true
   }
+</script>
+<script 
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+    type="text/javascript">
 </script>
 <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 <script src="//unpkg.com/docsify/lib/plugins/ga.min.js"></script>


### PR DESCRIPTION
Enabled dark and light mode with switch for docs using docsify-darklight-theme. For more customization [see here](https://boopathikumar018.github.io/docsify-darklight-theme)

**Light Mode :**

Before 

![image](https://user-images.githubusercontent.com/10001746/79606207-dddd1400-810e-11ea-99b7-361de04c0193.png)

After

![image](https://user-images.githubusercontent.com/10001746/79606246-ed5c5d00-810e-11ea-8113-7081be9b9216.png)

**Dark Mode:**

![image](https://user-images.githubusercontent.com/10001746/79606320-0d8c1c00-810f-11ea-89d1-6d8030f00e4d.png)
